### PR TITLE
HttpClient mandatory headers

### DIFF
--- a/SmsmodeTransport.php
+++ b/SmsmodeTransport.php
@@ -69,7 +69,11 @@ final class SmsmodeTransport extends AbstractTransport
         }
 
         $response = $this->client->request('POST', $endpoint, [
-            'headers' => ['X-Api-Key' => $this->apiKey],
+            'headers' => [
+                'X-Api-Key' => $this->apiKey,
+                'Content-Type' => 'application-json',
+                'Accept' => 'application/json',
+            ],
             'json' => array_filter($options),
         ]);
 


### PR DESCRIPTION
As mentioned in the documentation https://dev.smsmode.com/sms/v1/home in Content-Type in URL Encoding section.

HTTP request and response bodies are JSON objects, which is why Accept and Content-Type headers are mandatory and are implicitly added when the request is executed with the TEST button. If the Accept header is missing, a Not Acceptable (406) HTTP status code is returned. (Accept: application/json) The Content-Type header is only needed with POST and PATCH methods. If it is missing, an Unsupported Media Type (415) HTTP status code is returned. (Content-Type: application/json)